### PR TITLE
Closes #8

### DIFF
--- a/core/plugin/plugin_mount.py
+++ b/core/plugin/plugin_mount.py
@@ -4,4 +4,17 @@ from .plugin_mount_type import PluginMountType
 class PluginMount(metaclass=PluginMountType):
     """
     Mount point for plugins.
+
+    The mount point is a singleton so that multiple instances of the
+    mount point does not accidentally get created. This ensures that
+    there are only one copy of each plugin within the system.
     """
+
+    instance = None
+
+    def __new__(cls):
+        if cls.instance is not None:
+            return cls.instance
+        else:
+            inst = cls.instance = super(PluginMount, cls).__new__(cls)
+            return inst


### PR DESCRIPTION
Implemented a simple singleton for the Plugin Mount.
This will ensure that only one copy of a plugin exists in the system and that each plugin can only be executed once.

If there two instances was mistakenly made in code, the second one would be identical to the first one.